### PR TITLE
Change connect() definition and make port mandatory

### DIFF
--- a/API.md
+++ b/API.md
@@ -1207,7 +1207,9 @@ If `tls=true`, attempts to connect using a TLS connection.
 
 Resolves when connected.
 
-`async connect(hostname: string, port: number, tls?: boolean): Promise<Deno.Conn | null>`
+`async connect(hostname: string, port: number, tls?: boolean, path?: string): Promise<Deno.Conn | null>`
+
+Note: `path` parameter is ignored when websocket feature not enabled.
 
 ```ts
 client.connect("host", 6667);
@@ -1223,7 +1225,7 @@ When `websocket` feature enabled, also accepts `path` parameter as string.
 // Example remote endpoint URL
 const remoteUrl = "wss://irc.example.org:8097/pathTo/Irc";
 // Passing said endpoint URL to connect
-const client.connect("irc.example.org", 8097, true, "pathTo/Irc");
+client.connect("irc.example.org", 8097, true, "pathTo/Irc");
 ```
 
 ### command: ctcp

--- a/API.md
+++ b/API.md
@@ -430,7 +430,7 @@ const client = new Client({
     if (payload.type === "raw_input") {
       console.log(payload.msg);
     }
-  }
+  },
 });
 ```
 
@@ -1199,22 +1199,22 @@ client.clientinfo("#channel");
 
 ### command: connect
 
-Connects to a server using a hostname and an optional port.
-
-Default port to `6667`.
+Connects to a server using an hostname and a port.
 
 If `tls=true`, attempts to connect using a TLS connection.
 
+`path` is only used when client is instantiated with `websocket: true`.
+
 Resolves when connected.
 
-`async connect(hostname: string, port: number, tls?: boolean, path?: string): Promise<Deno.Conn | null>`
+`async connect(hostname: string, port: number, options?: { tls?: boolean, path?: string }): Promise<Deno.Conn | null>`
 
-Note: `path` parameter is ignored when websocket feature not enabled.
+Note: `path` parameter is ignored when websocket feature is not enabled.
 
 ```ts
 client.connect("host", 6667);
 
-client.connect("host", 7000, true); // with TLS
+client.connect("host", 7000, { tls: true }); // with TLS
 ```
 
 When `websocket` feature enabled defaults to port 80, or 443 if `tls=true`.
@@ -1224,8 +1224,12 @@ When `websocket` feature enabled, also accepts `path` parameter as string.
 ```ts
 // Example remote endpoint URL
 const remoteUrl = "wss://irc.example.org:8097/pathTo/Irc";
+
 // Passing said endpoint URL to connect
-client.connect("irc.example.org", 8097, true, "pathTo/Irc");
+client.connect("irc.example.org", 8097, {
+  tls: true,
+  path: "pathTo/Irc",
+});
 ```
 
 ### command: ctcp

--- a/API.md
+++ b/API.md
@@ -1215,6 +1215,8 @@ client.connect("host", 6667);
 client.connect("host", 7000, true); // with TLS
 ```
 
+When `websocket` feature enabled defaults to port 80, or 443 if `tls=true`.
+
 ### command: ctcp
 
 Sends a CTCP message to a `target` with a `command` and a `param`.

--- a/API.md
+++ b/API.md
@@ -1217,6 +1217,15 @@ client.connect("host", 7000, true); // with TLS
 
 When `websocket` feature enabled defaults to port 80, or 443 if `tls=true`.
 
+When `websocket` feature enabled, also accepts `path` parameter as string.
+
+```ts
+// Example remote endpoint URL
+const remoteUrl = "wss://irc.example.org:8097/pathTo/Irc";
+// Passing said endpoint URL to connect
+const client.connect("irc.example.org", 8097, true, "pathTo/Irc");
+```
+
 ### command: ctcp
 
 Sends a CTCP message to a `target` with a `command` and a `param`.

--- a/API.md
+++ b/API.md
@@ -335,7 +335,7 @@ const client = new Client({
 
 Enables auto reconnect.
 
-Takes boolean or `{ attempts?: number, delay?: number }`.
+Takes a boolean or `{ attempts?: number, delay?: number, exponentialBackoff?: boolean }`.
 
 Default to `false` or `{ attempts: 10, delay: 5 }` if set to `true`.
 
@@ -354,6 +354,18 @@ const client = new Client({
   reconnect: {
     attempts: 3,
     delay: 10,
+  },
+});
+```
+
+Tries to reconnect `5` times with an initial delay of `3` seconds with an exponential backoff:
+
+```ts
+const client = new Client({
+  reconnect: {
+    attempts: 5,
+    delay: 3,
+    exponentialBackoff: true,
   },
 });
 ```

--- a/API.md
+++ b/API.md
@@ -18,6 +18,7 @@
   - [option: serverPassword](#option-serverpassword)
   - [option: username](#option-username)
   - [option: verbose](#option-verbose)
+  - [option: websocket](#option-websocket)
 - [Events](#events)
   - [event: away_reply](#event-away_reply)
   - [event: connecting](#event-connecting)
@@ -432,6 +433,18 @@ const client = new Client({
   }
 });
 ```
+
+### option: websocket
+
+Enables alternate WebSocket transport per IRCv3 spec.
+
+```ts
+const client = new Client({
+  websocket: true,
+});
+```
+
+Default to `false` (use TCP)
 
 ## Events
 

--- a/client.ts
+++ b/client.ts
@@ -45,6 +45,7 @@ import topic from "./plugins/topic.ts";
 import usermodes from "./plugins/usermodes.ts";
 import verbose from "./plugins/verbose.ts";
 import version from "./plugins/version.ts";
+import websocket from "./plugins/websocket.ts";
 import whois from "./plugins/whois.ts";
 
 const plugins = [
@@ -90,6 +91,7 @@ const plugins = [
   usermodes,
   verbose,
   version,
+  websocket,
   whois,
 ];
 

--- a/core/client.ts
+++ b/core/client.ts
@@ -13,6 +13,36 @@ import {
 
 type AnyRawEventName = `raw:${AnyCommand | AnyReply | AnyError}`;
 
+/** Removes undefined trailing parameters from send() input. */
+export function removeUndefinedParameters(params: (string | undefined)[]) {
+  for (let i = params.length - 1; i >= 0; --i) {
+    params[i] === undefined ? params.pop() : i = 0;
+  }
+}
+
+/** Prefixes trailing parameter with ':'. */
+export function prefixTrailingParameter(params: (string | undefined)[]) {
+  const last = params.length - 1;
+  if (
+    params.length > 0 &&
+    (params[last]?.[0] === ":" || params[last]?.includes(" ", 1))
+  ) {
+    params[last] = ":" + params[last];
+  }
+}
+
+/** Prepares and encodes raw message. */
+export function encodeRawMessage(
+  command: string,
+  params: (string | undefined)[],
+  encoder: TextEncoder,
+) {
+  const raw = (command + " " + params.join(" ")).trimEnd() + "\r\n";
+  const bytes = encoder.encode(raw);
+  const tuple: [raw: string, bytes: Uint8Array] = [raw, bytes];
+  return tuple;
+}
+
 export interface CoreFeatures {
   options: EventEmitterOptions & {
     /** Size of the buffer that receives data from server.
@@ -201,24 +231,13 @@ export class CoreClient<
       return null;
     }
 
-    // Removes undefined trailing parameters.
-    for (let i = params.length - 1; i >= 0; --i) {
-      params[i] === undefined ? params.pop() : i = 0;
-    }
+    removeUndefinedParameters(params);
 
-    // Prefixes trailing parameter with ':'.
-    const last = params.length - 1;
-    if (
-      params.length > 0 &&
-      (params[last]?.[0] === ":" || params[last]?.includes(" ", 1))
-    ) {
-      params[last] = ":" + params[last];
-    }
+    prefixTrailingParameter(params);
+
+    const [raw, bytes] = encodeRawMessage(command, params, this.encoder);
 
     // Prepares and encodes raw message.
-    const raw = (command + " " + params.join(" ")).trimEnd() + "\r\n";
-    const bytes = this.encoder.encode(raw);
-
     try {
       await this.conn.write(bytes);
       return raw;

--- a/core/client.ts
+++ b/core/client.ts
@@ -148,6 +148,7 @@ export class CoreClient<
     hostname: string,
     port = PORT,
     tls = false,
+    _path?: string,
   ): Promise<Deno.Conn | null> {
     this.state.remoteAddr = { hostname, port, tls };
 

--- a/core/client.ts
+++ b/core/client.ts
@@ -47,7 +47,7 @@ export function generateRawEvents<
 }
 
 const BUFFER_SIZE = 4096;
-const PORT = 6667;
+export const PORT = 6667;
 
 export interface RemoteAddr {
   hostname: string;
@@ -75,8 +75,8 @@ export class CoreClient<
   protected hooks = new Hooks<CoreClient<TEvents>>(this);
 
   private decoder = new TextDecoder();
-  private encoder = new TextEncoder();
-  private parser = new Parser();
+  readonly encoder = new TextEncoder();
+  readonly parser = new Parser();
   private buffer: Uint8Array;
 
   constructor(

--- a/core/client.ts
+++ b/core/client.ts
@@ -53,6 +53,7 @@ export interface RemoteAddr {
   hostname: string;
   port: number;
   tls?: boolean;
+  path?: string;
 }
 
 /** How to connect to a server */

--- a/core/client.ts
+++ b/core/client.ts
@@ -47,7 +47,7 @@ export function generateRawEvents<
 }
 
 const BUFFER_SIZE = 4096;
-export const PORT = 6667;
+const PORT = 6667;
 
 export interface RemoteAddr {
   hostname: string;

--- a/core/client.ts
+++ b/core/client.ts
@@ -36,8 +36,10 @@ export function encodeRawMessage(
   command: string,
   params: (string | undefined)[],
   encoder: TextEncoder,
+  skipSuffix?: boolean,
 ) {
-  const raw = (command + " " + params.join(" ")).trimEnd() + "\r\n";
+  const raw = (command + " " + params.join(" ")).trimEnd() +
+    (skipSuffix ? "" : "\r\n");
   const bytes = encoder.encode(raw);
   const tuple: [raw: string, bytes: Uint8Array] = [raw, bytes];
   return tuple;
@@ -105,7 +107,7 @@ export class CoreClient<
   protected conn: Deno.Conn | null = null;
   protected hooks = new Hooks<CoreClient<TEvents>>(this);
 
-  private decoder = new TextDecoder();
+  readonly decoder = new TextDecoder();
   readonly encoder = new TextEncoder();
   readonly parser = new Parser();
   private buffer: Uint8Array;

--- a/core/client.ts
+++ b/core/client.ts
@@ -68,6 +68,11 @@ export interface CoreFeatures {
   utils: Record<never, never>;
 }
 
+export type ConnectOptions = {
+  tls?: boolean;
+  path?: string;
+};
+
 export function generateRawEvents<
   T extends keyof typeof PROTOCOL,
   U extends typeof PROTOCOL[T],
@@ -79,7 +84,6 @@ export function generateRawEvents<
 }
 
 const BUFFER_SIZE = 4096;
-const PORT = 6667;
 
 export interface RemoteAddr {
   hostname: string;
@@ -137,19 +141,19 @@ export class CoreClient<
     this.memorizeCurrentListenerCounts();
   }
 
-  /** Connects to a server using a hostname and an optional port.
-   *
-   * Default port to `6667`.
+  /** Connects to a server using an hostname and a port.
    *
    * If `tls=true`, attempts to connect using a TLS connection.
+   *
+   * `path` is only used when client is instantiated with `websocket: true`.
    *
    * Resolves when connected. */
   async connect(
     hostname: string,
-    port = PORT,
-    tls = false,
-    _path?: string,
+    port: number,
+    options?: ConnectOptions,
   ): Promise<Deno.Conn | null> {
+    const { tls = false } = options ?? {};
     this.state.remoteAddr = { hostname, port, tls };
 
     if (this.conn !== null) {

--- a/core/client_test.ts
+++ b/core/client_test.ts
@@ -46,7 +46,7 @@ describe("core/client", (test) => {
   test("connect to server with TLS", async () => {
     const { client } = mock();
 
-    client.connect("host", 6668, true);
+    client.connect("host", 6668, { tls: true });
     const addr = await client.once("connected");
 
     assertEquals(addr, {
@@ -59,7 +59,7 @@ describe("core/client", (test) => {
   test("fail to connect", async () => {
     const { client } = mock();
 
-    client.connect("bad_remote_host");
+    client.connect("bad_remote_host", 6667);
     const error = await client.once("error");
 
     assertEquals(error.name, "Error");
@@ -70,7 +70,7 @@ describe("core/client", (test) => {
     const { client } = mock();
 
     assertRejects(
-      () => client.connect("bad_remote_host"),
+      () => client.connect("bad_remote_host", 6667),
       Error,
       "Connection refused",
     );
@@ -79,7 +79,7 @@ describe("core/client", (test) => {
   test("send raw message to server", async () => {
     const { client, server } = mock();
 
-    await client.connect("host");
+    await client.connect("host", 6667);
 
     client.send("PING", "key");
     client.send("JOIN", "#channel", undefined);
@@ -116,7 +116,7 @@ describe("core/client", (test) => {
   test("throw on send if error is thrown", async () => {
     const { client } = mock();
 
-    await client.connect("host");
+    await client.connect("host", 6667);
 
     client.conn!.write = () => {
       throw new Error("Error while writing");
@@ -133,7 +133,7 @@ describe("core/client", (test) => {
     const { client, server } = mock();
     const messages = [];
 
-    await client.connect("host");
+    await client.connect("host", 6667);
 
     server.send("PING key");
     messages.push(await client.once("raw:ping"));
@@ -157,7 +157,7 @@ describe("core/client", (test) => {
   test("fail to receive raw messages from server if error is thrown", async () => {
     const { client, server } = mock();
 
-    await client.connect("host");
+    await client.connect("host", 6667);
 
     client.conn!.read = () => {
       throw new Error("Error while reading");
@@ -173,7 +173,7 @@ describe("core/client", (test) => {
   test("disconnect from server", async () => {
     const { client } = mock();
 
-    await client.connect("host");
+    await client.connect("host", 6667);
     const [addr] = await Promise.all([
       client.once("disconnected"),
       client.disconnect(),
@@ -189,7 +189,7 @@ describe("core/client", (test) => {
   test("be disconnected by server", async () => {
     const { client, server } = mock();
 
-    await client.connect("host");
+    await client.connect("host", 6667);
     server.shutdown();
     const msg = await client.once("disconnected");
 
@@ -213,7 +213,7 @@ describe("core/client", (test) => {
   test("throw on disconnect if error is thrown", async () => {
     const { client } = mock();
 
-    await client.connect("host");
+    await client.connect("host", 6667);
 
     client.conn!.close = () => {
       throw new Error("Error while closing");
@@ -241,7 +241,7 @@ describe("core/client", (test) => {
     const { client } = mock({}, plugins);
 
     assertRejects(
-      () => client.connect(""),
+      () => client.connect("host", 6667),
       Error,
       "Boom!",
     );
@@ -250,7 +250,7 @@ describe("core/client", (test) => {
   test("not throw if listeners bound to 'error'", async () => {
     const { client } = mock({}, plugins);
 
-    client.connect("");
+    client.connect("host", 6667);
     const error = await client.once("error");
 
     assertEquals(error.name, "Error");
@@ -275,7 +275,7 @@ describe("core/client", (test) => {
     const { client, server } = mock();
     const messages: Raw[] = [];
 
-    await client.connect("host");
+    await client.connect("host", 6667);
 
     client.on("raw", (msg) => messages.push(msg));
     client.on(["raw"], (msg) => messages.push(msg));

--- a/core/parsers.ts
+++ b/core/parsers.ts
@@ -60,7 +60,7 @@ export function parseSource(prefix: string): Source {
 
 // The following is called on each received raw message
 // and must favor performance over readability.
-function parseMessage(raw: string): Raw {
+export function parseMessage(raw: string): Raw {
   const msg = {} as Raw;
 
   // Indexes used to move through the raw string

--- a/deps.ts
+++ b/deps.ts
@@ -14,8 +14,3 @@ export { assertRejects } from "https://deno.land/std@0.224.0/assert/assert_rejec
 export { assertThrows } from "https://deno.land/std@0.224.0/assert/assert_throws.ts";
 
 export { Queue } from "https://deno.land/x/queue@1.2.0/mod.ts";
-
-export type { WebSocketClient } from "https://deno.land/x/websocket@v0.1.4/mod.ts";
-export { StandardWebSocketClient } from "https://deno.land/x/websocket@v0.1.4/mod.ts";
-
-

--- a/deps.ts
+++ b/deps.ts
@@ -8,6 +8,7 @@ export {
 
 export { assertArrayIncludes } from "https://deno.land/std@0.224.0/assert/assert_array_includes.ts";
 export { assertEquals } from "https://deno.land/std@0.224.0/assert/assert_equals.ts";
+export { assertNotEquals } from "https://deno.land/std@0.224.0/assert/assert_not_equals.ts";
 export { assertExists } from "https://deno.land/std@0.224.0/assert/assert_exists.ts";
 export { assertMatch } from "https://deno.land/std@0.224.0/assert/assert_match.ts";
 export { assertRejects } from "https://deno.land/std@0.224.0/assert/assert_rejects.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -4,13 +4,13 @@ export {
   green,
   red,
   stripColor,
-} from "https://deno.land/std@0.203.0/fmt/colors.ts";
+} from "https://deno.land/std@0.224.0/fmt/colors.ts";
 
-export { assertArrayIncludes } from "https://deno.land/std@0.203.0/assert/assert_array_includes.ts";
-export { assertEquals } from "https://deno.land/std@0.203.0/assert/assert_equals.ts";
-export { assertExists } from "https://deno.land/std@0.203.0/assert/assert_exists.ts";
-export { assertMatch } from "https://deno.land/std@0.203.0/assert/assert_match.ts";
-export { assertRejects } from "https://deno.land/std@0.203.0/assert/assert_rejects.ts";
-export { assertThrows } from "https://deno.land/std@0.203.0/assert/assert_throws.ts";
+export { assertArrayIncludes } from "https://deno.land/std@0.224.0/assert/assert_array_includes.ts";
+export { assertEquals } from "https://deno.land/std@0.224.0/assert/assert_equals.ts";
+export { assertExists } from "https://deno.land/std@0.224.0/assert/assert_exists.ts";
+export { assertMatch } from "https://deno.land/std@0.224.0/assert/assert_match.ts";
+export { assertRejects } from "https://deno.land/std@0.224.0/assert/assert_rejects.ts";
+export { assertThrows } from "https://deno.land/std@0.224.0/assert/assert_throws.ts";
 
 export { Queue } from "https://deno.land/x/queue@1.2.0/mod.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -14,3 +14,8 @@ export { assertRejects } from "https://deno.land/std@0.224.0/assert/assert_rejec
 export { assertThrows } from "https://deno.land/std@0.224.0/assert/assert_throws.ts";
 
 export { Queue } from "https://deno.land/x/queue@1.2.0/mod.ts";
+
+export type { WebSocketClient } from "https://deno.land/x/websocket@v0.1.4/mod.ts";
+export { StandardWebSocketClient } from "https://deno.land/x/websocket@v0.1.4/mod.ts";
+
+

--- a/plugins/antiflood_test.ts
+++ b/plugins/antiflood_test.ts
@@ -4,7 +4,7 @@ import { mock } from "../testing/mock.ts";
 
 describe("plugins/antiflood", (test) => {
   test("send two PRIVMSG with delay", async () => {
-    const { client, server } = await mock({ floodDelay: 250 });
+    const { client, server } = await mock({ floodDelay: 10 });
 
     client.privmsg("#channel", "Hello world");
     client.privmsg("#channel", "Hello world, again");
@@ -16,7 +16,7 @@ describe("plugins/antiflood", (test) => {
     ]);
 
     // Wait for second message to make it through
-    await delay(1000);
+    await delay(100);
     raw = server.receive();
 
     // Second message now dispatched to server

--- a/plugins/quit_test.ts
+++ b/plugins/quit_test.ts
@@ -9,7 +9,7 @@ describe("plugins/quit", (test) => {
     const raw = [];
     const connections = [];
 
-    await client.connect("");
+    await client.connect("", 6667);
     raw.push(
       ...(await Promise.all([
         client.quit(),
@@ -18,7 +18,7 @@ describe("plugins/quit", (test) => {
     );
     connections.push(client.conn);
 
-    await client.connect("");
+    await client.connect("", 6667);
     raw.push(
       ...(await Promise.all([
         client.quit("Goodbye!"),

--- a/plugins/reconnect.ts
+++ b/plugins/reconnect.ts
@@ -69,7 +69,7 @@ export default createPlugin(
 
     const { hostname, port, tls } = remoteAddr;
     timeout = setTimeout(
-      async () => await client.connect(hostname, port, tls),
+      async () => await client.connect(hostname, port, { tls }),
       delay * 1000 * Math.pow(backoffFactor, currentAttempts - 1),
     );
   };

--- a/plugins/reconnect_test.ts
+++ b/plugins/reconnect_test.ts
@@ -15,7 +15,7 @@ describe("plugins/reconnect", (test) => {
     client.on("reconnecting", () => reconnecting++);
     client.on("error", noop);
 
-    client.connect("bad_remote_host");
+    client.connect("bad_remote_host", 6667);
     await client.once("reconnecting");
 
     assertEquals(reconnecting, 1);
@@ -33,7 +33,7 @@ describe("plugins/reconnect", (test) => {
     client.on("reconnecting", () => reconnecting++);
     client.on("error", noop);
 
-    await client.connect("");
+    await client.connect("", 6667);
     server.send("ERROR :Closing link: (user@host) [Client exited]");
     await client.once("reconnecting");
 
@@ -52,7 +52,7 @@ describe("plugins/reconnect", (test) => {
     client.on("reconnecting", () => reconnecting++);
     client.on("error", noop);
 
-    await client.connect("");
+    await client.connect("", 6667);
 
     // attempt 1
     server.send("ERROR :Closing link: (user@host) [Client exited]");
@@ -85,7 +85,7 @@ describe("plugins/reconnect", (test) => {
     client.on("reconnecting", () => reconnecting++);
     client.on("error", noop);
 
-    client.connect("bad_remote_host");
+    client.connect("bad_remote_host", 6667);
 
     assertEquals(reconnecting, 0);
   });
@@ -97,7 +97,7 @@ describe("plugins/reconnect", (test) => {
     );
 
     assertRejects(
-      async () => await client.connect(""),
+      async () => await client.connect("", 6667),
       Error,
       "plugins/reconnect requires an error listener",
     );

--- a/plugins/reconnect_test.ts
+++ b/plugins/reconnect_test.ts
@@ -19,6 +19,8 @@ describe("plugins/reconnect", (test) => {
     await client.once("reconnecting");
 
     assertEquals(reconnecting, 1);
+
+    await client.once("error"); // wait for timeout clearing
   });
 
   test("reconnect on server error", async () => {
@@ -36,6 +38,8 @@ describe("plugins/reconnect", (test) => {
     await client.once("reconnecting");
 
     assertEquals(reconnecting, 1);
+
+    await client.once("connecting"); // wait for timeout clearing
   });
 
   test("reset attemps when RPL_WELCOME is received", async () => {
@@ -67,6 +71,8 @@ describe("plugins/reconnect", (test) => {
     await client.once("reconnecting");
 
     assertEquals(reconnecting, 3);
+
+    await client.once("connecting"); // wait for timeout clearing
   });
 
   test("not reconnect if disabled", async () => {

--- a/plugins/registration_test.ts
+++ b/plugins/registration_test.ts
@@ -17,7 +17,7 @@ describe("plugins/registration", (test) => {
     (client.state as { capabilities: typeof client.state.capabilities })
       .capabilities = [];
 
-    await client.connect("");
+    await client.connect("", 6667);
     const raw = server.receive();
 
     assertEquals(raw, [
@@ -35,7 +35,7 @@ describe("plugins/registration", (test) => {
     (client.state as { capabilities: typeof client.state.capabilities })
       .capabilities = [];
 
-    await client.connect("");
+    await client.connect("", 6667);
     const raw = server.receive();
 
     assertEquals(raw, [
@@ -51,7 +51,7 @@ describe("plugins/registration", (test) => {
       { withConnection: false },
     );
 
-    await client.connect("");
+    await client.connect("", 6667);
     const raw = server.receive();
 
     assertEquals(raw, [
@@ -67,7 +67,7 @@ describe("plugins/registration", (test) => {
       { ...options, password: "password" },
     );
 
-    await client.connect("");
+    await client.connect("", 6667);
     const raw = server.receive();
     assertEquals(raw, [
       "CAP REQ multi-prefix",
@@ -84,7 +84,7 @@ describe("plugins/registration", (test) => {
       { withConnection: false },
     );
 
-    await client.connect("");
+    await client.connect("", 6667);
     server.send(":serverhost 903 user :SASL authentication successful");
     await client.once("raw:rpl_saslsuccess");
     const raw = server.receive();

--- a/plugins/verbose_test.ts
+++ b/plugins/verbose_test.ts
@@ -40,7 +40,7 @@ describe("plugins/verbose", (test) => {
       { withConnection: false },
     );
 
-    client.connect("host");
+    client.connect("host", 6667);
     await client.once("connected");
     server.send("ERROR :Closing link: (user@host) [Client exited]");
     await client.once("error");
@@ -85,7 +85,7 @@ describe("plugins/verbose", (test) => {
       { withConnection: false },
     );
 
-    client.connect("");
+    client.connect("", 6667);
     await client.once("connected");
     client.send("JOIN", "#channel");
     server.send(":me!user@host JOIN #channel");

--- a/plugins/websocket.ts
+++ b/plugins/websocket.ts
@@ -32,7 +32,7 @@ export default createPlugin("websocket", [])<WebsocketFeatures>(
       client.emitError("read", new Error(event.toString()));
     };
 
-    client.hooks.hookCall("connect", async (_, serverAndPath, port, tls) => {
+    client.hooks.hookCall("connect", (_, serverAndPath, port, tls) => {
       port = port ?? PORT;
       const websocketPrefix = tls ? "wss://" : "ws://";
       const websocketUrl = `${websocketPrefix}${serverAndPath}:${port}`;

--- a/plugins/websocket.ts
+++ b/plugins/websocket.ts
@@ -44,11 +44,11 @@ export default createPlugin("websocket", [])<WebsocketFeatures>(
       client.emitError("read", new Error(event.toString()));
     };
 
-    client.hooks.hookCall("connect", (_, serverAndPath, port, tls) => {
+    client.hooks.hookCall("connect", (_, hostname, port, tls, path) => {
       port = port ?? (tls ? TLS_PORT : INSECURE_PORT);
       const websocketPrefix = tls ? "wss://" : "ws://";
       const websocketUrl = new URL(
-        `${websocketPrefix}${serverAndPath}:${port}`,
+        `${websocketPrefix}${hostname}:${port}${path ? "/" + path : ""}`,
       );
       if (websocket !== null) {
         websocket.close(1000);

--- a/plugins/websocket.ts
+++ b/plugins/websocket.ts
@@ -1,0 +1,103 @@
+import { PORT } from "../core/client.ts";
+import { parseMessage } from "../core/parsers.ts";
+import { createPlugin } from "../core/plugins.ts";
+import { StandardWebSocketClient, WebSocketClient } from "../deps.ts";
+
+interface WebsocketFeatures {
+  options: {
+    websocket?: boolean;
+  };
+}
+
+export default createPlugin("websocket", [])<WebsocketFeatures>(
+  (client, options) => {
+    if (!options.websocket) return;
+
+    let websocket: WebSocketClient | null = null;
+
+    const openHandler = () => {
+      client.emit("connected", client.state.remoteAddr);
+    };
+
+    const messageHandler = (message: MessageEvent) => {
+      try {
+        const msg = parseMessage(message.data);
+        client.emit(`raw:${msg.command}`, msg);
+      } catch (error) {
+        client.emitError("read", error);
+      }
+    };
+
+    const errorHandler = (error: string | symbol) => {
+      client.emitError("read", new Error(error.toString()));
+    };
+
+    client.hooks.hookCall("connect", async (_, hostname, port, tls) => {
+      port = port ?? PORT;
+      const websocketPrefix = tls ? "wss://" : "ws://";
+      const websocketUrl = `${websocketPrefix}${hostname}:${port}`;
+      if (websocket !== null) {
+        await websocket.close(0);
+      }
+
+      client.state.remoteAddr = { hostname, port, tls };
+      const { remoteAddr } = client.state;
+      client.emit("connecting", remoteAddr);
+
+      try {
+        websocket = new StandardWebSocketClient(websocketUrl);
+        websocket.on("error", errorHandler);
+        websocket.on("open", openHandler);
+        websocket.on("message", messageHandler);
+      } catch (error) {
+        client.emitError("connect", error);
+        return null;
+      }
+
+      return null;
+    });
+
+    client.hooks.hookCall("send", (_, command, ...params) => {
+      if (websocket === null) {
+        client.emitError("write", "Unable to send message", client.send);
+        return null;
+      }
+      // Removes undefined trailing parameters.
+      for (let i = params.length - 1; i >= 0; --i) {
+        params[i] === undefined ? params.pop() : i = 0;
+      }
+
+      // Prefixes trailing parameter with ':'.
+      const last = params.length - 1;
+      if (
+        params.length > 0 &&
+        (params[last]?.[0] === ":" || params[last]?.includes(" ", 1))
+      ) {
+        params[last] = ":" + params[last];
+      }
+
+      // Prepares and encodes raw message.
+      const raw = (command + " " + params.join(" ")).trimEnd() + "\r\n";
+      const bytes = client.encoder.encode(raw);
+
+      try {
+        websocket.send(bytes);
+        return raw;
+      } catch (error) {
+        client.emitError("write", error);
+        return null;
+      }
+    });
+
+    client.hooks.hookCall("disconnect", async () => {
+      try {
+        await websocket?.close(0);
+        client.emit("disconnected", client.state.remoteAddr);
+      } catch (error) {
+        client.emitError("close", error);
+      } finally {
+        websocket = null;
+      }
+    });
+  },
+);

--- a/plugins/websocket_test.ts
+++ b/plugins/websocket_test.ts
@@ -84,7 +84,7 @@ describe("plugins/websocket", (test) => {
       nick: "me",
       websocket: true,
     });
-    const server = new MockWebSocketServer(fakeUrl);
+    let server = new MockWebSocketServer(fakeUrl);
     // Ensure error events are passed
     const errorMessage = "failed!";
     const errorTest = (error: Error) => {
@@ -104,6 +104,14 @@ describe("plugins/websocket", (test) => {
     server.close();
     await client.connect(fakeHost);
     await delay(25);
+    client.disconnect();
+    // Ensure double connect works
+    server = new MockWebSocketServer(fakeUrl);
+    await client.connect(fakeHost);
+    await delay(25);
+    await client.connect(fakeHost);
+    await delay(25);
+    server.close();
     client.disconnect();
   });
 });

--- a/plugins/websocket_test.ts
+++ b/plugins/websocket_test.ts
@@ -15,6 +15,7 @@ describe("plugins/websocket", (test) => {
   ];
   const serverMessage = ":localhost 001 me :Hello from the server, me";
   const decoder = new TextDecoder();
+
   test("Connects to server and attempts to register", async () => {
     const client = new MockClient({
       nick: "me",
@@ -35,7 +36,10 @@ describe("plugins/websocket", (test) => {
       });
     });
 
-    await client.connect(fakeHost, undefined, undefined, fakePath);
+    await client.connect(fakeHost, 80, {
+      tls: false,
+      path: fakePath,
+    });
     // Required to execute websocket micro tasks
     await delay(50);
 
@@ -66,14 +70,8 @@ describe("plugins/websocket", (test) => {
       });
     });
 
-    // Test undefined port codepath
-    await client.connect(secureHost, undefined, true);
-    // Required to execute websocket micro tasks
-    await delay(50);
-    client.disconnect();
-
     // Test manual port codepath
-    await client.connect(secureHost, 443, true);
+    await client.connect(secureHost, 443, { tls: true });
     await delay(50);
 
     server.close();
@@ -103,14 +101,14 @@ describe("plugins/websocket", (test) => {
     };
     client.on("error", connectErrorTest);
     server.close();
-    await client.connect(fakeHost);
+    await client.connect(fakeHost, 80);
     await delay(25);
     client.disconnect();
     // Ensure double connect works
     server = new MockWebSocketServer(fakeUrl);
-    await client.connect(fakeHost);
+    await client.connect(fakeHost, 80);
     await delay(25);
-    await client.connect(fakeHost);
+    await client.connect(fakeHost, 80);
     await delay(25);
     server.close();
     client.disconnect();

--- a/plugins/websocket_test.ts
+++ b/plugins/websocket_test.ts
@@ -6,10 +6,10 @@ import { delay, describe } from "../testing/helpers.ts";
 describe("plugins/websocket", (test) => {
   test("Connects to server and attempts to register", async () => {
     const clientMessages = [
-      "NICK me\r\n",
-      "USER me 0 * me\r\n",
-      "CAP REQ multi-prefix\r\n",
-      "CAP END\r\n",
+      "NICK me",
+      "USER me 0 * me",
+      "CAP REQ multi-prefix",
+      "CAP END",
     ];
     const serverMessage = ":localhost 001 me :Hello from the server, me";
     const fakeHost = "localhost";

--- a/plugins/websocket_test.ts
+++ b/plugins/websocket_test.ts
@@ -1,27 +1,27 @@
 import { MockClient } from "./../testing/client.ts";
 import { Server as MockWebSocketServer } from "npm:mock-socket";
-import { assertEquals } from "../deps.ts";
+import { assertEquals, assertNotEquals } from "../deps.ts";
 import { delay, describe } from "../testing/helpers.ts";
 
 describe("plugins/websocket", (test) => {
+  const fakeHost = "localhost";
+  const fakeUrl = `ws://${fakeHost}`;
+  const clientMessages = [
+    "NICK me",
+    "USER me 0 * me",
+    "CAP REQ multi-prefix",
+    "CAP END",
+  ];
+  const serverMessage = ":localhost 001 me :Hello from the server, me";
+  const decoder = new TextDecoder();
   test("Connects to server and attempts to register", async () => {
-    const clientMessages = [
-      "NICK me",
-      "USER me 0 * me",
-      "CAP REQ multi-prefix",
-      "CAP END",
-    ];
-    const serverMessage = ":localhost 001 me :Hello from the server, me";
-    const fakeHost = "localhost";
-    const fakeUrl = `ws://${fakeHost}`;
-    const decoder = new TextDecoder();
-    let messageCounter = 0;
-
     const client = new MockClient({
       nick: "me",
       websocket: true,
     });
     const server = new MockWebSocketServer(fakeUrl);
+
+    let messageCounter = 0;
     server.on("connection", (socket) => {
       socket.on("message", (payload) => {
         const array = payload as Uint8Array;
@@ -39,6 +39,71 @@ describe("plugins/websocket", (test) => {
     await delay(50);
 
     server.close();
+    client.disconnect();
+  });
+
+  test("Handles text and TLS protocols", async () => {
+    const secureHost = "localhost";
+    const secureUrl = "wss://localhost";
+    const client = new MockClient({
+      nick: "me",
+      websocket: true,
+    });
+    const server = new MockWebSocketServer(secureUrl, {
+      selectProtocol: () => "text.ircv3.net",
+    });
+    let messageCounter = 0;
+    server.on("connection", (socket) => {
+      socket.on("message", (payload) => {
+        const data = payload as string;
+        assertEquals(data, clientMessages[messageCounter++]);
+        // Send rpl_welcome when client is done
+        if (messageCounter === 4) {
+          socket.send(serverMessage);
+          messageCounter = 0;
+        }
+      });
+    });
+
+    // Test undefined port codepath
+    await client.connect(secureHost, undefined, true);
+    // Required to execute websocket micro tasks
+    await delay(50);
+    client.disconnect();
+
+    // Test manual port codepath
+    await client.connect(secureHost, 443, true);
+    await delay(50);
+
+    server.close();
+    client.disconnect();
+  });
+
+  test("Client handles and passes error states", async () => {
+    const client = new MockClient({
+      nick: "me",
+      websocket: true,
+    });
+    const server = new MockWebSocketServer(fakeUrl);
+    // Ensure error events are passed
+    const errorMessage = "failed!";
+    const errorTest = (error: Error) => {
+      assertEquals(error.message, errorMessage);
+    };
+    client.on("error", errorTest);
+    client.emitError("read", Error(errorMessage));
+    await delay(25);
+    client.off("error", errorTest);
+    client.disconnect();
+    // Ensure invalid state on connect handled
+    const connectErrorTest = (error: Error) => {
+      console.log(error.message);
+      assertNotEquals(error.message, undefined);
+    };
+    client.on("error", connectErrorTest);
+    server.close();
+    await client.connect(fakeHost);
+    await delay(25);
     client.disconnect();
   });
 });

--- a/plugins/websocket_test.ts
+++ b/plugins/websocket_test.ts
@@ -13,8 +13,7 @@ describe("plugins/websocket", (test) => {
     ];
     const serverMessage = ":localhost 001 me :Hello from the server, me";
     const fakeHost = "localhost";
-    const fakePort = 8067;
-    const fakeUrl = `ws://${fakeHost}:${fakePort}`;
+    const fakeUrl = `ws://${fakeHost}`;
     const decoder = new TextDecoder();
     let messageCounter = 0;
 
@@ -35,7 +34,7 @@ describe("plugins/websocket", (test) => {
       });
     });
 
-    await client.connect(fakeHost, fakePort);
+    await client.connect(fakeHost);
     // Required to execute websocket micro tasks
     await delay(50);
 

--- a/plugins/websocket_test.ts
+++ b/plugins/websocket_test.ts
@@ -5,7 +5,8 @@ import { delay, describe } from "../testing/helpers.ts";
 
 describe("plugins/websocket", (test) => {
   const fakeHost = "localhost";
-  const fakeUrl = `ws://${fakeHost}`;
+  const fakePath = "irc";
+  const fakeUrl = `ws://${fakeHost}/${fakePath}`;
   const clientMessages = [
     "NICK me",
     "USER me 0 * me",
@@ -34,7 +35,7 @@ describe("plugins/websocket", (test) => {
       });
     });
 
-    await client.connect(fakeHost);
+    await client.connect(fakeHost, undefined, undefined, fakePath);
     // Required to execute websocket micro tasks
     await delay(50);
 

--- a/plugins/websocket_test.ts
+++ b/plugins/websocket_test.ts
@@ -1,0 +1,45 @@
+import { MockClient } from "./../testing/client.ts";
+import { Server as MockWebSocketServer } from "npm:mock-socket";
+import { assertEquals } from "../deps.ts";
+import { delay, describe } from "../testing/helpers.ts";
+
+describe("plugins/websocket", (test) => {
+  test("Connects to server and attempts to register", async () => {
+    const clientMessages = [
+      "NICK me\r\n",
+      "USER me 0 * me\r\n",
+      "CAP REQ multi-prefix\r\n",
+      "CAP END\r\n",
+    ];
+    const serverMessage = ":localhost 001 me :Hello from the server, me";
+    const fakeHost = "localhost";
+    const fakePort = 8067;
+    const fakeUrl = `ws://${fakeHost}:${fakePort}`;
+    const decoder = new TextDecoder();
+    let messageCounter = 0;
+
+    const client = new MockClient({
+      nick: "me",
+      websocket: true,
+    });
+    const server = new MockWebSocketServer(fakeUrl);
+    server.on("connection", (socket) => {
+      socket.on("message", (payload) => {
+        const array = payload as Uint8Array;
+        const data = decoder.decode(array);
+        assertEquals(data, clientMessages[messageCounter++]);
+        // Send rpl_welcome when client is done
+        if (messageCounter >= 4) {
+          socket.send(serverMessage);
+        }
+      });
+    });
+
+    await client.connect(fakeHost, fakePort);
+    // Required to execute websocket micro tasks
+    await delay(50);
+
+    server.close();
+    client.disconnect();
+  });
+});

--- a/testing/conn.ts
+++ b/testing/conn.ts
@@ -61,4 +61,6 @@ export class MockConn extends EventEmitter<Events> implements Deno.Conn {
   ref(): void {}
 
   unref(): void {}
+
+  [Symbol.dispose](): void {}
 }

--- a/testing/mock.ts
+++ b/testing/mock.ts
@@ -24,7 +24,7 @@ export async function mock(
   const server = new MockServer(client);
 
   if (withConnection) {
-    await client.connect("");
+    await client.connect("", 6667);
     server.receive();
   }
 


### PR DESCRIPTION
Sorry for the delay.

I made a small update to your branch related to websockets.

`connect()` changes:

- options are now embedded in object
- port is now mandatory (to avoid confusion between TLS, websocket, etc.)

Example:

```ts
client.connect("irc.example.org", 8097, {
  tls: true,
  path: "pathTo/Irc",
});
```

Feel free to merge this change to your initial PR.

I think I will merge it after.

Thank you again for your nice contribution.